### PR TITLE
collapse_whitespace compatible with inline elements

### DIFF
--- a/tiny-html-minifier.php
+++ b/tiny-html-minifier.php
@@ -81,8 +81,8 @@ class TinyHtmlMinifier {
             $this->setSkip($name, $type);
 
             if(!empty($tag_content)) {
-                $content = (isset($tag_parts[1])) ? $tag_parts[1] : '';
-                if(!empty($content)) {
+                $content = isset($tag_parts[1]) ? trim($tag_parts[1]) : '';
+                if($content !== '') {
                     $this->build[] = [
                         'content' => $this->compact($content, $name, $element),
                         'type' => 'content'

--- a/tiny-html-minifier.php
+++ b/tiny-html-minifier.php
@@ -81,7 +81,7 @@ class TinyHtmlMinifier {
             $this->setSkip($name, $type);
 
             if(!empty($tag_content)) {
-                $content = isset($tag_parts[1]) ? trim($tag_parts[1]) : '';
+                $content = (isset($tag_parts[1])) ? $tag_parts[1] : '';
                 if($content !== '') {
                     $this->build[] = [
                         'content' => $this->compact($content, $name, $element),

--- a/tiny-html-minifier.php
+++ b/tiny-html-minifier.php
@@ -13,6 +13,33 @@ class TinyHtmlMinifier {
                 'textarea',
                 'script'
             ],
+            'inline' => [
+                'b',
+                'big',
+                'i',
+                'small',
+                'tt',
+                'abbr',
+                'acronym',
+                'cite',
+                'code',
+                'dfn',
+                'em',
+                'kbd',
+                'strong',
+                'samp',
+                'var',
+                'a',
+                'bdo',
+                'br',
+                'img',
+                'map',
+                'object',
+                'q',
+                'span',
+                'sub',
+                'sup',
+            ],
             'hard' => [
                 '!doctype',
                 'body',
@@ -48,7 +75,8 @@ class TinyHtmlMinifier {
             $this->build[] = [
                 'name' => $name,
                 'content' => $element,
-                'type' => $type
+                'type' => $type,
+                'inline' => in_array($name, $this->elements['inline']),
             ];
 
             $this->setSkip($name, $type);
@@ -56,10 +84,14 @@ class TinyHtmlMinifier {
             if(!empty($tag_content)) {
                 $content = (isset($tag_parts[1])) ? $tag_parts[1] : '';
                 if(!empty($content)) {
-                    $this->build[] = [
-                        'content' => $this->compact($content, $name, $element),
-                        'type' => 'content'
-                    ];
+                    $content = $this->compact($content, $name, $element);
+                    if(!empty($content)) {
+                       $this->build[] = [
+                            'content' => $content,
+                            'type' => 'content',
+                            'inline' => true,
+                        ];
+                    }
                 }
             }
         }
@@ -174,7 +206,16 @@ class TinyHtmlMinifier {
     // Build html
     function buildHtml() {
         $out = '';
-        foreach($this->build as $build) {
+
+        foreach($this->build as $key => $build) {
+            
+            if(!empty($this->options['collapse_whitespace']) && $key != 0) {
+                $prev = $this->build[$key-1];
+                if($prev['inline'] == true && $build['inline'] == true && $prev['type'] != 'open' && $build['type'] != 'close') {
+                    $out .= ' ';
+                }
+            }
+
             $out .= $build['content'];
         }
         return $out;

--- a/tiny-html-minifier.php
+++ b/tiny-html-minifier.php
@@ -84,7 +84,6 @@ class TinyHtmlMinifier {
                 $content = (isset($tag_parts[1])) ? $tag_parts[1] : '';
                 if(!empty($content)) {
                     $this->build[] = [
-                        //'content' => $content,
                         'content' => $this->compact($content, $name, $element),
                         'type' => 'content'
                     ];
@@ -201,7 +200,7 @@ class TinyHtmlMinifier {
     // Build html
     function buildHtml() {
         $out = '';
-        foreach($this->build as $key => $build) {
+        foreach($this->build as $build) {
 
             if(!empty($this->options['collapse_whitespace'])) {
                 

--- a/tiny-html-minifier.php
+++ b/tiny-html-minifier.php
@@ -40,11 +40,6 @@ class TinyHtmlMinifier {
                 'sub',
                 'sup',
             ],
-            'no_space' => [
-                ',',
-                '.',
-                '!',
-            ],
             'hard' => [
                 '!doctype',
                 'body',
@@ -80,8 +75,7 @@ class TinyHtmlMinifier {
             $this->build[] = [
                 'name' => $name,
                 'content' => $element,
-                'type' => $type,
-                'inline' => in_array($name, $this->elements['inline']),
+                'type' => $type
             ];
 
             $this->setSkip($name, $type);
@@ -89,14 +83,11 @@ class TinyHtmlMinifier {
             if(!empty($tag_content)) {
                 $content = (isset($tag_parts[1])) ? $tag_parts[1] : '';
                 if(!empty($content)) {
-                    $content = $this->compact($content, $name, $element);
-                    if(!empty($content)) {
-                       $this->build[] = [
-                            'content' => $content,
-                            'type' => 'content',
-                            'inline' => true,
-                        ];
-                    }
+                    $this->build[] = [
+                        //'content' => $content,
+                        'content' => $this->compact($content, $name, $element),
+                        'type' => 'content'
+                    ];
                 }
             }
         }
@@ -191,7 +182,6 @@ class TinyHtmlMinifier {
             return $content;
         } elseif(
             in_array($name, $this->elements['hard']) ||
-            !empty($this->options['collapse_whitespace']) ||
             $this->head
             ) {
             return $this->minifyHard($content);
@@ -211,18 +201,21 @@ class TinyHtmlMinifier {
     // Build html
     function buildHtml() {
         $out = '';
-
         foreach($this->build as $key => $build) {
-            
-            if(!empty($this->options['collapse_whitespace']) && $key != 0) {
-                $prev = $this->build[$key-1];
-                if($prev['inline'] == true && $build['inline'] == true && $prev['type'] != 'open' && $build['type'] != 'close' && !in_array(substr($build['content'], 0, 1), $this->elements['no_space'])) {
-                    $out .= ' ';
-                }
+
+            if(!empty($this->options['collapse_whitespace'])) {
+                
+                if(strlen(trim($build['content'])) == 0)
+                    continue;
+                
+                elseif($build['type'] != 'content' && !in_array($build['name'], $this->elements['inline']))
+                    trim($build['content']);
+                
             }
 
             $out .= $build['content'];
         }
+        
         return $out;
     }
 

--- a/tiny-html-minifier.php
+++ b/tiny-html-minifier.php
@@ -40,6 +40,11 @@ class TinyHtmlMinifier {
                 'sub',
                 'sup',
             ],
+            'no_space' => [
+                ',',
+                '.',
+                '!',
+            ],
             'hard' => [
                 '!doctype',
                 'body',
@@ -211,7 +216,7 @@ class TinyHtmlMinifier {
             
             if(!empty($this->options['collapse_whitespace']) && $key != 0) {
                 $prev = $this->build[$key-1];
-                if($prev['inline'] == true && $build['inline'] == true && $prev['type'] != 'open' && $build['type'] != 'close') {
+                if($prev['inline'] == true && $build['inline'] == true && $prev['type'] != 'open' && $build['type'] != 'close' && !in_array(substr($build['content'], 0, 1), $this->elements['no_space'])) {
                     $out .= ' ';
                 }
             }


### PR DESCRIPTION
Updated collapse_whitespace to be more friendly to inline elements. While it can often be desirable to collapse whitespace between block elements, this has a negative impact on inline elements.

Example:
<div>
  <p>Paragraph with <strong>Bold Text</strong> and some <em>emphasized text</em><p>
  <p>Paragraph with <strong>Bold Text</strong> and some <em>emphasized text</em><p>
</div>

Should minify to:
<div><p>Paragraph with <strong>Bold Text</strong> and some <em>emphasized text</em><p><p>Paragraph with <strong>Bold Text</strong> and some <em>emphasized text</em><p></div>

Not:
<div><p>Paragraph with<strong>Bold Text</strong>and some<em>emphasized text</em><p><p>Paragraph with<strong>Bold Text</strong>and some<em>emphasized text</em><p></div>