### PR TITLE
Fix parsing '>' in element content

### DIFF
--- a/src/TinyHtmlMinifier.php
+++ b/src/TinyHtmlMinifier.php
@@ -85,7 +85,7 @@ class TinyHtmlMinifier
     // Walk trough html
     private function walk(&$part)
     {
-        $tag_parts = explode('>', $part);
+      $tag_parts = explode('>', $part, 2);  // Limit of 2 parts to prevent issues with '>' in content (eg. JS comparison)
         $tag_content = $tag_parts[0];
 
         if (!empty($tag_content)) {

--- a/src/TinyHtmlMinifier.php
+++ b/src/TinyHtmlMinifier.php
@@ -82,10 +82,10 @@ class TinyHtmlMinifier
         return $this->output;
     }
 
-    // Walk trough html
+    // Walk through html
     private function walk(&$part)
     {
-      $tag_parts = explode('>', $part, 2);  // Limit of 2 parts to prevent issues with '>' in content (eg. JS comparison)
+        $tag_parts = explode('>', $part, 2);  // Limit of 2 parts to prevent issues with '>' in content (eg. JS comparison)
         $tag_content = $tag_parts[0];
 
         if (!empty($tag_content)) {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -66,6 +66,10 @@
     <script>
         console.log('Script tags are not minified');
         console.log('This is inside a script tag');
+        // Test greater than sign not stripped from scripts
+        if (1 > 2) {
+          console.log('This should not happen!');
+        }
     </script>
 
 </body>


### PR DESCRIPTION
This pull request fixes some cases where the HTML file is parsed incorrectly when there is a greater than symbol inside of an element content, such as a script tag, as reported in issue #21 .

For example, for the following (simple) input: `<script>var isBigger = 2 > 1 ? 'yes' : 'no'</script>`

When parsed using the current code in this repository, the result is: `<script>var isBigger = 2 </script>`

And with this PR, the result is: `<script>var isBigger = 2 > 1 ? 'yes' : 'no'</script>`

I've also modified the sample HTML in the tests directory to include an example of this behaviour.

I've used `diff` to compare the output of the compile test before and after this modification, and nothing other than the intended chances is modified. I can't see a reason why this fix would cause issues to anything else, though am happy to fix my code if anyone can see any potential issues.